### PR TITLE
Write a lesson to review RESTful API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### IntelliJ IDEA ###
+.idea/
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,31 +2,33 @@
 
 ## Learning Goals
 
-- Learning Goal 1
-- Learning Goal 2
+- Review the REST API.
 
-## Introduction
+## RESTful API Review
 
-A 1-2 sentence summary of what will be covered.
+REST (REpresentational State Transfer) is a common way of client-server
+interaction. It is a set of rules that define how data should be queried and
+managed. A service that is written with these rules is called a RESTful service,
+or REST service. Since Spring supports REST services, we'll be working with the
+REST API quite a bit in this module to build one with Spring Boot. With that
+said, let's review the six principles of a REST service:
 
-## Topic 1
 
-Discuss the topic of the reading. Break into sections and sub-sections as
-appropriate to help with the reader's orientation with the material and future
-referencing.
+- **Client-Server Interaction Model:** the application rendering the data and
+  the application processing the data are kept separate.
+- **Stateless:** Every request from a client must contain the necessary
+  information to retrieve or manipulate data on the server. It cannot rely on
+  any stored state on the server.
+- **Cacheable:** A request-response value can be cached on the server so that
+  the server can return repeated requests without having to reprocess data.
+- **Uniform Interface:** All RESTful services follow a consistent naming
+  convention which makes it easy to work across different services.
+- **Layered System:** The client request may be routed through other services
+  before reaching the server. A client doesn’t know if it is directly connected
+  to a server.
+- **Code on Demand:** A client can request executable code from the server in
+  the form of applets or scripts.
 
-## Topic 2
-
-Discuss the topic of the reading. Break into sections and sub-sections as
-appropriate to help with the reader's orientation with the material and future
-referencing.
-
-## Conclusion
-
-A short one or two paragraph summary of the contents of the lessons, recapping
-the learning goals.
-
-## Resources
-
-- [Resource Link 1](example.com)
-- [Resource Link 2](example.com)
+Be sure to follow
+[REST resource naming conventions](https://restfulapi.net/resource-naming/) when
+building a REST service.


### PR DESCRIPTION
This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.